### PR TITLE
미세먼지 예보 기능 추가

### DIFF
--- a/BE/src/main/java/com/dust10/group10/api/ApiResponse.java
+++ b/BE/src/main/java/com/dust10/group10/api/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.dust10.group10.api;
 
 import com.dust10.group10.domain.DustStatus;
+import com.dust10.group10.domain.Forecast;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
@@ -12,6 +13,7 @@ public class ApiResponse {
     private int statusCode;
     private String stationName;
     private List<DustStatus> objects;
+    private Forecast forecast;
 
     public ApiResponse(HttpStatus status, int statusCode, String stationName) {
         this.status = status;
@@ -28,5 +30,11 @@ public class ApiResponse {
     public ApiResponse(HttpStatus status, int statusCode) {
         this.status = status;
         this.statusCode = statusCode;
+    }
+
+    public ApiResponse(HttpStatus status, int statusCode, Forecast forecast) {
+        this.status = status;
+        this.statusCode = statusCode;
+        this.forecast = forecast;
     }
 }

--- a/BE/src/main/java/com/dust10/group10/config/WebConfig.java
+++ b/BE/src/main/java/com/dust10/group10/config/WebConfig.java
@@ -4,7 +4,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 

--- a/BE/src/main/java/com/dust10/group10/controller/ForecastController.java
+++ b/BE/src/main/java/com/dust10/group10/controller/ForecastController.java
@@ -1,11 +1,8 @@
 package com.dust10.group10.controller;
 
 import com.dust10.group10.api.ApiResponse;
-import com.dust10.group10.domain.DustStatus;
-import com.dust10.group10.domain.Station;
 import com.dust10.group10.service.ForecastService;
 import com.dust10.group10.service.LocationService;
-import com.google.gson.JsonArray;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +40,11 @@ public class ForecastController {
     }
 
     @GetMapping("/forecast")
-    public String forecast() {
-        return forecastService.forecastDust();
+    public ApiResponse forecast() {
+        try {
+            return new ApiResponse(HttpStatus.OK, 200, forecastService.forecastDust());
+        } catch (IOException e) {
+            return new ApiResponse(HttpStatus.BAD_REQUEST, 400);
+        }
     }
 }

--- a/BE/src/main/java/com/dust10/group10/domain/DustStatus.java
+++ b/BE/src/main/java/com/dust10/group10/domain/DustStatus.java
@@ -3,7 +3,7 @@ package com.dust10.group10.domain;
 import lombok.*;
 
 @NoArgsConstructor
-@Getter @Setter
+@Getter
 @ToString
 public class DustStatus {
     private String pm10Value;

--- a/BE/src/main/java/com/dust10/group10/domain/Forecast.java
+++ b/BE/src/main/java/com/dust10/group10/domain/Forecast.java
@@ -1,0 +1,23 @@
+package com.dust10.group10.domain;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class Forecast {
+    private String imageUrl1;
+    private String imageUrl2;
+    private String imageUrl3;
+    private String informGrade;
+    private String informOverall;
+
+    public Forecast(String imageUrl1, String imageUrl2, String imageUrl3,
+                    String informGrade, String informOverall) {
+        this.imageUrl1 = imageUrl1;
+        this.imageUrl2 = imageUrl2;
+        this.imageUrl3 = imageUrl3;
+        this.informGrade = informGrade;
+        this.informOverall = informOverall;
+    }
+}

--- a/BE/src/main/java/com/dust10/group10/service/ForecastService.java
+++ b/BE/src/main/java/com/dust10/group10/service/ForecastService.java
@@ -1,31 +1,29 @@
 package com.dust10.group10.service;
 
 import com.dust10.group10.domain.DustStatus;
+import com.dust10.group10.domain.Forecast;
 import com.dust10.group10.utils.OpenApiConnect;
 import com.google.gson.*;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.dust10.group10.utils.OpenApiURL.SERVICE_KEY;
-
 
 @Service
 public class ForecastService {
 
     public List<DustStatus> measureDust(String stationName) throws IOException {
         String json = new OpenApiConnect().apiConnectStationMeasure(stationName);
-        return (jsonParser(json));
+        return dustStatusJsonParser(json);
     }
 
-    private List<DustStatus> jsonParser(String json) {
+    public Forecast forecastDust() throws IOException {
+        String json = new OpenApiConnect().apiConnectForecast();
+        return forecastJsonParser(json);
+    }
+
+    private List<DustStatus> dustStatusJsonParser(String json) {
         List<DustStatus> dustStatuses = new ArrayList<>();
         JsonParser jp = new JsonParser();
         JsonElement je = jp.parse(json);
@@ -41,36 +39,16 @@ public class ForecastService {
         return dustStatuses;
     }
 
-    public String forecastDust() {
-        StringBuilder sb = new StringBuilder();
-        try {
-            StringBuilder urlBuilder = new StringBuilder("http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth"); /*URL*/
-            urlBuilder.append("?").append(URLEncoder.encode("ServiceKey", "UTF-8")).append("=").append(SERVICE_KEY); /*Service Key*/
-            urlBuilder.append("&" + URLEncoder.encode("numOfRows", "UTF-8") + "=" + URLEncoder.encode("24", "UTF-8")); /*한 페이지 결과 수 (조회 날짜로 검색 시 사용 안함)*/
-            urlBuilder.append("&" + URLEncoder.encode("pageNo", "UTF-8") + "=" + URLEncoder.encode("1", "UTF-8")); /*페이지 번호(조회 날짜로 검색 시 사용 안함)*/
-            urlBuilder.append("&" + URLEncoder.encode("searchDate", "UTF-8") + "=" + URLEncoder.encode("2020-03-31", "UTF-8")); /*통보시간 검색 (조회 날짜 입력 없을 경우 한달동안 예보통보 발령 날짜의 리스트 정보를 확인)*/
-            urlBuilder.append("&" + URLEncoder.encode("InformCode", "UTF-8") + "=" + URLEncoder.encode("PM10", "UTF-8")); /*통보코드검색 (PM10 : 미세먼지 PM25 : 초미세먼지 O3 : 오존)*/
-            urlBuilder.append("&" + URLEncoder.encode("ver", "UTF-8") + "=" + URLEncoder.encode("1.1", "UTF-8")); /*버전별 상세 결과 참고문서 참조*/
-            urlBuilder.append("&").append(URLEncoder.encode("_returnType", "UTF-8")).append("=").append("json"); /*JSON형식으로 표시*/
-            URL url = new URL(urlBuilder.toString());
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Content-type", "application/json");
-            BufferedReader rd;
-            if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
-                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
-            }
-            String line;
-            while ((line = rd.readLine()) != null) {
-                sb.append(line);
-            }
-            rd.close();
-            conn.disconnect();
-        } catch (IOException e) {
-
-        }
-        return sb.toString();
+    private Forecast forecastJsonParser(String json) {
+        JsonParser jp = new JsonParser();
+        JsonElement je = jp.parse(json);
+        JsonArray jsonArray = je.getAsJsonObject().get("list").getAsJsonArray();
+        JsonObject jsonObject = (JsonObject) jsonArray.get(0);
+        String imageUrl1 = jsonObject.get("imageUrl1").getAsString();
+        String imageUrl2 = jsonObject.get("imageUrl2").getAsString();
+        String imageUrl3 = jsonObject.get("imageUrl3").getAsString();
+        String informGrade = jsonObject.get("informGrade").getAsString();
+        String informOverall = jsonObject.get("informOverall").getAsString();
+        return new Forecast(imageUrl1, imageUrl2, imageUrl3, informGrade, informOverall);
     }
 }

--- a/BE/src/main/java/com/dust10/group10/service/LocationService.java
+++ b/BE/src/main/java/com/dust10/group10/service/LocationService.java
@@ -5,16 +5,12 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 
 @Service
 public class LocationService {
-
-    private final Logger logger = LoggerFactory.getLogger(LocationService.class);
 
     public String locateStation(double xAxis, double yAxis) throws IOException {
         OpenApiConnect apiConnect = new OpenApiConnect();

--- a/BE/src/main/java/com/dust10/group10/utils/OpenApiConnect.java
+++ b/BE/src/main/java/com/dust10/group10/utils/OpenApiConnect.java
@@ -1,20 +1,16 @@
 package com.dust10.group10.utils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.time.LocalDate;
 
 import static com.dust10.group10.utils.OpenApiURL.*;
 
 public class OpenApiConnect {
-
-    private final Logger logger = LoggerFactory.getLogger(OpenApiConnect.class);
 
     public String kakaoApiConnectBuilder(double xAxis, double yAxis) throws IOException {
         StringBuilder urlBuilder = new StringBuilder(KAKAO_OPEN_API_URL);
@@ -45,6 +41,17 @@ public class OpenApiConnect {
         paramAppendUrl(urlBuilder, "&", "stationName", stationName);
         paramAppendUrl(urlBuilder, "&", "dataTerm", "DAILY");
         paramAppendUrl(urlBuilder, "&", "ver", "1.3");
+        URL url = new URL(urlBuilder.toString());
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        apiUrlRequest(url, conn);
+        return responseBuilder(conn);
+    }
+
+    public String apiConnectForecast() throws IOException {
+        StringBuilder urlBuilder = requestApiConnect(FORECAST_OPEN_API_URL);
+        paramAppendUrl(urlBuilder, "&","InformCode", "PM10");
+        paramAppendUrl(urlBuilder, "&", "ver", "1.1");
+        paramAppendUrl(urlBuilder, "&", "searchDate", LocalDate.now());
         URL url = new URL(urlBuilder.toString());
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         apiUrlRequest(url, conn);

--- a/BE/src/main/java/com/dust10/group10/utils/OpenApiURL.java
+++ b/BE/src/main/java/com/dust10/group10/utils/OpenApiURL.java
@@ -1,11 +1,11 @@
 package com.dust10.group10.utils;
 
 public class OpenApiURL {
-    public static final String KAKAO_OPEN_API_URL = "https://dapi.kakao.com/v2/local/geo/transcoord.json";
-    public static final String FIND_STATION_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/MsrstnInfoInqireSvc/getNearbyMsrstnList";
-    public static final String MEASURE_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty";
-    public static final String FORECAST_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth";
+    protected static final String KAKAO_OPEN_API_URL = "https://dapi.kakao.com/v2/local/geo/transcoord.json";
+    protected static final String FIND_STATION_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/MsrstnInfoInqireSvc/getNearbyMsrstnList";
+    protected static final String MEASURE_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty";
+    protected static final String FORECAST_OPEN_API_URL = "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth";
 
-    public static final String KAKAO_KEY = "KakaoAK c2de27fae60a8e007a44e7d8a411efec";
-    public static final String SERVICE_KEY = "pd7oMfpEAuYkyy7Mm3b9cZfe49GY1p%2B4EKHYoipIgk9RrZfCitVfVH3LGPo%2Fb93v9%2FHPnQlgOX7stocZtomyeQ%3D%3D";
+    protected static final String KAKAO_KEY = "KakaoAK c2de27fae60a8e007a44e7d8a411efec";
+    protected static final String SERVICE_KEY = "pd7oMfpEAuYkyy7Mm3b9cZfe49GY1p%2B4EKHYoipIgk9RrZfCitVfVH3LGPo%2Fb93v9%2FHPnQlgOX7stocZtomyeQ%3D%3D";
 }


### PR DESCRIPTION
- Forecast: 다음날 예보 이미지링크3개, 예보 등급, 예보총평

- ForecastService
  - 파서메서드 구체적 명시

- OpenApiConnect
  - apiConnectForecast: LocalDate.now()로 오늘자 미세먼지 예보 데이터를 받게 합니다. 새벽 0시부터 새벽 6시까지는 오늘자 데이터를 받을 수 없어서 어제자로 받을 수 있도록 수정해야합니다.